### PR TITLE
Update appveyor configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,9 @@ platform:
 configuration: Release
 
 install:
-  - ps: Install-Product node $env:nodejs_version
-  - npm install -g windows-build-tools
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm config set python python2.7
+  - npm config set msvs_version 2015
   - npm install --ignore-scripts
 
 build_script:


### PR DESCRIPTION
Since VSBuildTools are already installed on appveyor there is no need to run `windows-build-tools`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pronebird/windows-security/3)
<!-- Reviewable:end -->
